### PR TITLE
Fix a small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Music, Radio and Podcast player for Ubuntu made with Flutter.
 |![](.github/wide_light.png) | ![](.github/wide_dark.png) |
 |![](.github/slim_light.png)|![](.github/slim_dark.png)|
 
-## Planed features
+## Planned features
 
 - [X] play local audio files
 - [X] Filter local files


### PR DESCRIPTION
Loving this already but had to make a small and correction.

Do you think `pubspec.lock` should also be added to `.gitignore`? I'm building on a newer `dart` so have to stash or restore that and I suspect it should be ignored ...