### PR TITLE
Revert "Don't stage libmfx1 on arm64 as it's amd64 only.  Fixes #35 (#48)"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -79,6 +79,7 @@ parts:
       - libgsm1
       - liblapack3
       - liblilv-0-0
+      - libmfx1
       - libmysofa1
       - libnorm1
       - libnuma1
@@ -112,8 +113,6 @@ parts:
       - libswscale5
       - libsrt1.4-gnutls
       - ocl-icd-libopencl1
-      - on amd64:
-        - libmfx1
     prime:
       - usr/lib/*/blas/libblas.so*
       - usr/lib/*/lapack/liblapack.so*


### PR DESCRIPTION
This reverts commit e747533fe55796d8978a3566d201edb5c0e31777.

As a temp fix until we know what causes the problem in edge 
Tested in a fresh lunar VM as well and the error still exists