### PR TITLE
Don't die on FFI exceptions

### DIFF
--- a/lib/app/local_audio/local_audio_model.dart
+++ b/lib/app/local_audio/local_audio_model.dart
@@ -3,10 +3,12 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
 import 'package:metadata_god/metadata_god.dart';
 import 'package:mime_type/mime_type.dart';
 import 'package:musicpod/app/common/audio_filter.dart';
 import 'package:musicpod/app/common/constants.dart';
+import 'package:musicpod/app/music_app.dart';
 import 'package:musicpod/data/audio.dart';
 import 'package:musicpod/utils.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
@@ -221,8 +223,11 @@ class LocalAudioModel extends SafeChangeNotifier {
         }
       }
 
+      int failures = 0;
+      int total = 0;
       audios = {};
       for (var e in onlyFiles) {
+        total++;
         try {
           final metadata = await MetadataGod.readMetadata(file: e.path);
 
@@ -247,10 +252,16 @@ class LocalAudioModel extends SafeChangeNotifier {
 
           audios?.add(audio);
         } catch (e) {
-          print(e);
+          failures++;
         }
       }
-
+      if (failures > 0) {
+        MusicApp.scaffoldKey.currentState?.showSnackBar(
+          SnackBar(
+            content: Text('Failed to import $failures of $total audio files.'),
+          ),
+        );
+      }
       notifyListeners();
     }
   }

--- a/lib/app/local_audio/local_audio_model.dart
+++ b/lib/app/local_audio/local_audio_model.dart
@@ -223,28 +223,32 @@ class LocalAudioModel extends SafeChangeNotifier {
 
       audios = {};
       for (var e in onlyFiles) {
-        final metadata = await MetadataGod.readMetadata(file: e.path);
+        try {
+          final metadata = await MetadataGod.readMetadata(file: e.path);
 
-        final audio = Audio(
-          path: e.path,
-          audioType: AudioType.local,
-          artist: metadata.artist,
-          title: metadata.title,
-          album:
-              '${metadata.album} ${metadata.discTotal != null && metadata.discTotal! > 1 ? metadata.discNumber : ''}',
-          albumArtist: metadata.albumArtist,
-          discNumber: metadata.discNumber,
-          discTotal: metadata.discTotal,
-          durationMs: metadata.durationMs,
-          fileSize: metadata.fileSize,
-          genre: metadata.genre,
-          pictureData: metadata.picture?.data,
-          pictureMimeType: metadata.picture?.mimeType,
-          trackNumber: metadata.trackNumber,
-          year: metadata.year,
-        );
+          final audio = Audio(
+            path: e.path,
+            audioType: AudioType.local,
+            artist: metadata.artist,
+            title: metadata.title,
+            album:
+                '${metadata.album} ${metadata.discTotal != null && metadata.discTotal! > 1 ? metadata.discNumber : ''}',
+            albumArtist: metadata.albumArtist,
+            discNumber: metadata.discNumber,
+            discTotal: metadata.discTotal,
+            durationMs: metadata.durationMs,
+            fileSize: metadata.fileSize,
+            genre: metadata.genre,
+            pictureData: metadata.picture?.data,
+            pictureMimeType: metadata.picture?.mimeType,
+            trackNumber: metadata.trackNumber,
+            year: metadata.year,
+          );
 
-        audios?.add(audio);
+          audios?.add(audio);
+        } catch (e) {
+          print(e);
+        }
       }
 
       notifyListeners();

--- a/lib/app/local_audio/local_audio_model.dart
+++ b/lib/app/local_audio/local_audio_model.dart
@@ -259,6 +259,7 @@ class LocalAudioModel extends SafeChangeNotifier {
         MusicApp.scaffoldKey.currentState?.showSnackBar(
           SnackBar(
             content: Text('Failed to import $failures of $total audio files.'),
+            backgroundColor: Colors.red,
           ),
         );
       }

--- a/lib/app/music_app.dart
+++ b/lib/app/music_app.dart
@@ -30,6 +30,8 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 class MusicApp extends StatelessWidget {
   const MusicApp({super.key});
 
+  static final GlobalKey<ScaffoldMessengerState> scaffoldKey = GlobalKey();
+
   @override
   Widget build(BuildContext context) {
     return YaruTheme(
@@ -42,6 +44,7 @@ class MusicApp extends StatelessWidget {
           supportedLocales: supportedLocales,
           onGenerateTitle: (context) => 'Music',
           home: _App.create(context),
+          scaffoldMessengerKey: scaffoldKey,
         );
       },
     );


### PR DESCRIPTION
Previously, any failure to load the metadata for any audio file would stop loading the entire music collection. This PR makes it so that, instead of dying, it just prints out the error and skips that file.

Should I change this so that it shows a toast of some sort with a message of "Failed to load &lt;file path&gt;" instead?