### PR TITLE
Use flutter_media_metadata instead of metadata_god

### DIFF
--- a/lib/data/audio.dart
+++ b/lib/data/audio.dart
@@ -211,7 +211,7 @@ class Audio {
       description: map['description'],
       website: map['website'],
       title: map['title'],
-      durationMs: map['durationMs']?.toDouble(),
+      durationMs: map['durationMs']?.toInt(),
       artist: map['artist'],
       album: map['album'],
       albumArtist: map['albumArtist'],

--- a/lib/data/audio.dart
+++ b/lib/data/audio.dart
@@ -25,7 +25,7 @@ class Audio {
   final String? title;
 
   /// The ID3-Tag duration of the audio file. It can be null if was not set
-  final double? durationMs;
+  final int? durationMs;
 
   /// The ID3-Tag artist(s) of the audio file.
   final String? artist;
@@ -95,7 +95,7 @@ class Audio {
     String? description,
     String? website,
     String? title,
-    double? durationMs,
+    int? durationMs,
     String? artist,
     String? album,
     String? albumArtist,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:desktop_notifications/desktop_notifications.dart';
 import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
-import 'package:metadata_god/metadata_god.dart';
 import 'package:mpris_service/mpris_service.dart';
 import 'package:musicpod/app/common/constants.dart';
 import 'package:musicpod/service/library_service.dart';
@@ -37,7 +36,6 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   MediaKit.ensureInitialized();
   await YaruWindowTitleBar.ensureInitialized();
-  MetadataGod.initialize();
 
   libraryService.init();
   runApp(const MusicPod());

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <flutter_media_metadata/flutter_media_metadata_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <handy_window/handy_window_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
@@ -19,6 +20,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_media_metadata_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterMediaMetadataPlugin");
+  flutter_media_metadata_plugin_register_with_registrar(flutter_media_metadata_registrar);
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  flutter_media_metadata
   gtk
   handy_window
   media_kit_libs_linux
@@ -14,7 +15,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
-  metadata_god
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,9 @@ dependencies:
   intl: ^0.18.0
   media_kit: ^0.0.11
   media_kit_libs_linux: ^1.0.2
-  metadata_god: ^0.4.1
+  flutter_media_metadata:
+    git:
+      url: https://github.com/aleksrutins/flutter_media_metadata
   mime_type: ^1.0.0
   mpris_service:
     git:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,6 +66,8 @@ parts:
 
   deps:
     plugin: nil
+    build-packages:
+      - libmediafile-dev
     stage-packages:
       - libaom3
       - libass9
@@ -111,6 +113,7 @@ parts:
       - libpostproc55
       - libswscale5
       - libsrt1.4-gnutls
+      - libmediafile
       - ocl-icd-libopencl1
       - on amd64:
         - libmfx1
@@ -174,6 +177,7 @@ parts:
       - usr/lib/*/libavcodec.so*
       - usr/lib/*/libavutil.so*
       - usr/lib/*/libswresample.so*
+      - usr/lib/*/libmediafile.so*
 
   # Find files provided by the base and platform snap and ensure they aren't
   # duplicated in this snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,7 +67,7 @@ parts:
   deps:
     plugin: nil
     build-packages:
-      - libmediafile-dev
+      - libmediainfo-dev
     stage-packages:
       - libaom3
       - libass9
@@ -113,7 +113,7 @@ parts:
       - libpostproc55
       - libswscale5
       - libsrt1.4-gnutls
-      - libmediafile
+      - libmediainfo0v5
       - ocl-icd-libopencl1
       - on amd64:
         - libmfx1
@@ -177,7 +177,10 @@ parts:
       - usr/lib/*/libavcodec.so*
       - usr/lib/*/libavutil.so*
       - usr/lib/*/libswresample.so*
-      - usr/lib/*/libmediafile.so*
+      - usr/lib/*/libmediainfo.so*
+      - usr/lib/*/libmms.so*
+      - usr/lib/*/libtinyxml2.so*
+      - usr/lib/*/libzen.so*
 
   # Find files provided by the base and platform snap and ensure they aren't
   # duplicated in this snap


### PR DESCRIPTION
This switches from `metadata_god` to `flutter_media_metadata`.

This PR is a draft because it currently depends on my fork pending <https://github.com/alexmercerind/flutter_media_metadata/pull/34> to fix some build issues. It's also really slow, so I'm going to see if I can multithread it or something.