### PR TITLE
Move file loading out of the Widget tree

### DIFF
--- a/lib/app/local_audio/failed_imports_content.dart
+++ b/lib/app/local_audio/failed_imports_content.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:musicpod/l10n/l10n.dart';
+
+class FailedImportsContent extends StatelessWidget {
+  const FailedImportsContent({
+    super.key,
+    required this.failedImports,
+  });
+
+  final List<String> failedImports;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SizedBox(
+      height: 400,
+      width: 400,
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(10.0),
+                child: Text(
+                  context.l10n.failedToImport,
+                  style: TextStyle(
+                    color: theme.colorScheme.onInverseSurface,
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              )
+            ],
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: failedImports.length,
+              itemBuilder: (context, index) {
+                return ListTile(
+                  title: Text(
+                    failedImports[index],
+                    style: TextStyle(color: theme.colorScheme.onInverseSurface),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/local_audio/local_audio_page.dart
+++ b/lib/app/local_audio/local_audio_page.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:musicpod/app/common/tabbed_page.dart';
 import 'package:musicpod/app/local_audio/album_view.dart';
 import 'package:musicpod/app/local_audio/artists_view.dart';
+import 'package:musicpod/app/local_audio/failed_imports_content.dart';
 import 'package:musicpod/app/local_audio/local_audio_model.dart';
 import 'package:musicpod/app/local_audio/local_audio_search_field.dart';
 import 'package:musicpod/app/local_audio/local_audio_search_page.dart';
 import 'package:musicpod/app/local_audio/titles_view.dart';
-import 'package:musicpod/app/common/tabbed_page.dart';
 import 'package:musicpod/l10n/l10n.dart';
 import 'package:provider/provider.dart';
 import 'package:yaru_icons/yaru_icons.dart';
@@ -22,6 +23,21 @@ class LocalAudioPage extends StatefulWidget {
 
 class _LocalAudioPageState extends State<LocalAudioPage> {
   int _selectedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<LocalAudioModel>().init(
+          onFail: (failedImports) => ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              duration: const Duration(seconds: 10),
+              content: FailedImportsContent(
+                failedImports: failedImports,
+              ),
+            ),
+          ),
+        );
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -67,5 +67,6 @@
     "station": "Station",
     "country": "Country",
     "tag": "Tag",
-    "all": "All"
+    "all": "All",
+    "failedToImport": "Failed to import the following files:"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:mpris_service/mpris_service.dart';
 import 'package:musicpod/app/common/constants.dart';
 import 'package:musicpod/musicpod.dart';
 import 'package:musicpod/service/library_service.dart';
+import 'package:musicpod/service/local_audio_service.dart';
 import 'package:musicpod/service/podcast_service.dart';
 import 'package:musicpod/service/radio_service.dart';
 import 'package:radio_browser_api/radio_browser_api.dart';
@@ -27,6 +28,7 @@ Future<void> main() async {
 
   registerService<MPRIS>(() => mpris);
   registerService<LibraryService>(LibraryService.new);
+  registerService<LocalAudioService>(LocalAudioService.new);
   registerService<PodcastService>(PodcastService.new);
   registerService<Connectivity>(Connectivity.new);
   registerService<NotificationsClient>(NotificationsClient.new);

--- a/lib/musicpod.dart
+++ b/lib/musicpod.dart
@@ -6,8 +6,6 @@ import 'package:yaru/yaru.dart';
 class MusicPod extends StatelessWidget {
   const MusicPod({super.key});
 
-  static final GlobalKey<ScaffoldMessengerState> scaffoldKey = GlobalKey();
-
   @override
   Widget build(BuildContext context) {
     return YaruTheme(
@@ -21,9 +19,7 @@ class MusicPod extends StatelessWidget {
           onGenerateTitle: (context) => 'MusicPod',
           home: App.create(
             context: context,
-            showSnackBar: scaffoldKey.currentState?.showSnackBar,
           ),
-          scaffoldMessengerKey: scaffoldKey,
         );
       },
     );

--- a/lib/service/local_audio_service.dart
+++ b/lib/service/local_audio_service.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:metadata_god/metadata_god.dart';
+import 'package:mime_type/mime_type.dart';
+import 'package:musicpod/app/common/constants.dart';
+import 'package:musicpod/data/audio.dart';
+import 'package:musicpod/utils.dart';
+import 'package:xdg_directories/xdg_directories.dart';
+
+class LocalAudioService {
+  String? _directory;
+  String? get directory => _directory;
+  Future<void> setDirectory(String? value) async {
+    if (value == null || value == _directory) return;
+    await writeSetting(kDirectoryProperty, value).then((_) {
+      _updateDirectory(value);
+    });
+  }
+
+  final _directoryController = StreamController<bool>.broadcast();
+  Stream<bool> get directoryChanged => _directoryController.stream;
+  void _updateDirectory(String? value) {
+    _directory = value;
+    _directoryController.add(true);
+  }
+
+  Set<Audio>? _audios;
+  Set<Audio>? get audios => _audios;
+  set audios(Set<Audio>? value) {
+    _updateAudios(value);
+  }
+
+  final _audiosController = StreamController<bool>.broadcast();
+  Stream<bool> get audiosChanged => _audiosController.stream;
+  void _updateAudios(Set<Audio>? value) {
+    _audios = value;
+    _audiosController.add(true);
+  }
+
+  final _failedImports = <String>[];
+  Future<List<String>> init() async {
+    _failedImports.clear();
+    _directory = await readSetting(kDirectoryProperty);
+    _directory ??= getUserDirectory('MUSIC')?.path;
+
+    if (_directory != null) {
+      final allFileSystemEntities = Set<FileSystemEntity>.from(
+        await _getFlattenedFileSystemEntities(path: directory!),
+      );
+
+      final onlyFiles = <FileSystemEntity>[];
+
+      for (var fileSystemEntity in allFileSystemEntities) {
+        if (!await FileSystemEntity.isDirectory(fileSystemEntity.path) &&
+            _validType(fileSystemEntity.path)) {
+          onlyFiles.add(fileSystemEntity);
+        }
+      }
+
+      audios = {};
+      for (var e in onlyFiles) {
+        try {
+          final metadata = await MetadataGod.readMetadata(file: e.path);
+
+          final audio = Audio(
+            path: e.path,
+            audioType: AudioType.local,
+            artist: metadata.artist ?? '',
+            title: metadata.title ?? e.path,
+            album: metadata.album == null
+                ? ''
+                : '${metadata.album} ${metadata.discTotal != null && metadata.discTotal! > 1 ? metadata.discNumber : ''}',
+            albumArtist: metadata.albumArtist,
+            discNumber: metadata.discNumber,
+            discTotal: metadata.discTotal,
+            durationMs: metadata.durationMs,
+            fileSize: metadata.fileSize,
+            genre: metadata.genre,
+            pictureData: metadata.picture?.data,
+            pictureMimeType: metadata.picture?.mimeType,
+            trackNumber: metadata.trackNumber,
+            year: metadata.year,
+          );
+
+          audios?.add(audio);
+        } catch (error) {
+          _failedImports.add(e.path);
+        }
+      }
+    }
+    _audiosController.add(true);
+    _directoryController.add(true);
+    return _failedImports;
+  }
+
+  bool _validType(String path) => mime(path)?.contains('audio') ?? false;
+
+  Future<List<FileSystemEntity>> _getFlattenedFileSystemEntities({
+    required String path,
+  }) async {
+    return await Directory(path)
+        .list(recursive: true, followLinks: false)
+        .toList();
+  }
+}


### PR DESCRIPTION
- moves file loading into a service class
- directory and audios are stored there
- took this as a chance to get any material component import out of the local audio model

CC @aleksrutins 