### PR TITLE
Add publish action

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,34 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  FLUTTER_VERSION: '3.13.x'
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: ${{env.FLUTTER_VERSION}}
+      - run: sudo apt update
+      - run: sudo apt install -y clang cmake curl libgtk-3-dev ninja-build pkg-config unzip libunwind-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libmpv-dev
+      - run: flutter pub get
+      - run: flutter build linux -v        
+        id: build
+      - uses: snapcore/action-build@v1
+        if: steps.build.outcome == 'success'
+        id: build_snap
+      - uses: snapcore/action-publish@v1
+        if: steps.build_snap.outcome == 'success'
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build_snap.outputs.snap }}
+          release: edge


### PR DESCRIPTION
Hi @kenvandine :wave: :smile_cat: 

Really would try this continuos delivery deployment on github instead of doing this on snapcraft
I followed https://snapcraft.io/docs/snapcraft-authentication
and
https://github.com/snapcore/action-build
and
https://github.com/snapcore/action-publish
Would be nice if you could try if I made any mistake