### PR TITLE
Add StartupWMClass

### DIFF
--- a/snap/gui/musicpod.desktop
+++ b/snap/gui/musicpod.desktop
@@ -7,3 +7,4 @@ Exec=musicpod %U
 Icon=music-app
 Terminal=false
 Categories=AudioVideo;Audio;
+StartupWMClass=musicpod


### PR DESCRIPTION
This is needed so that the dash/dock can recognize the appropriate icon when the app is running and enables pinning the app to the dash/dock.

StartupWMClass=musicpod

musicpod should be the name of the binary that is running