### PR TITLE
[service]: fix the previous button 

### DIFF
--- a/lib/src/player/player_service.dart
+++ b/lib/src/player/player_service.dart
@@ -316,11 +316,8 @@ class PlayerService {
       if (currentIndex == 0) {
         return;
       }
-
-      nextAudio = queue.$2.elementAt(currentIndex - 1);
-
-      if (nextAudio == null) return;
-      _setAudio(nextAudio);
+      _setAudio(queue.$2.elementAt(currentIndex - 1));
+      nextAudio = queue.$2.elementAt(queue.$2.indexOf(audio!) + 1);
 
       await play();
     }


### PR DESCRIPTION
The index of the next song was not updated, when we change the song. As a result, each song, that's played by pressing the previous button, will play again, if we press the next button. What this PR does is, sets audio index, to the previous song of the current audio. Then updates the index of the next song. Not sure about this, but I think we should not return if the next song is null.

fixes #382 