### PR TITLE
Refactor to reduce repaints

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -89,6 +89,8 @@ const kCardColorNeutral = Color.fromARGB(255, 133, 133, 133);
 
 const kAudioQueueThreshHold = 100;
 
+const kMainPageIconPadding = EdgeInsets.only(right: 4.0);
+
 const kLikedAudiosFileName = 'likedAudios.json';
 const kLikedAudios = 'likedAudios';
 const kTagFavsFileName = 'tagFavs.json';
@@ -121,6 +123,9 @@ const kPodcastIndex = 'podcastIndex';
 const kNeverShowImportFails = 'neverShowImportFails';
 const kLastCountryCode = 'lastCountryCode';
 const kSearchResult = 'searchResult';
+const kPodcasts = 'podcasts';
+const kRadio = 'radio';
+const kNewPlaylist = 'newPlaylist';
 
 const shops = <String, String>{
   'https://us.7digital.com/': '7digital',

--- a/lib/src/app/app.dart
+++ b/lib/src/app/app.dart
@@ -142,8 +142,8 @@ class _AppState extends State<App> with WidgetsBindingObserver {
     // Radio
     final radioModel = context.read<RadioModel>();
 
-    // Player
-    final isFullScreen = context.select((PlayerModel m) => m.fullScreen);
+    // AppModel
+    final isFullScreen = context.select((AppModel m) => m.fullScreen);
 
     // Library
     final libraryModel = context.watch<LibraryModel>();
@@ -180,7 +180,6 @@ class _AppState extends State<App> with WidgetsBindingObserver {
 
     final yaruMasterDetailPage = MasterDetailPage(
       setIndex: libraryModel.setIndex,
-      totalListAmount: libraryModel.totalListAmount,
       index: libraryModel.index,
       masterItems: createMasterItems(
         libraryModel: libraryModel,

--- a/lib/src/app/app_model.dart
+++ b/lib/src/app/app_model.dart
@@ -7,4 +7,12 @@ class AppModel extends SafeChangeNotifier {
     _showWindowControls = value;
     notifyListeners();
   }
+
+  bool? _fullScreen;
+  bool? get fullScreen => _fullScreen;
+  void setFullScreen(bool? value) {
+    if (value == null || value == _fullScreen) return;
+    _fullScreen = value;
+    notifyListeners();
+  }
 }

--- a/lib/src/app/master_detail_page.dart
+++ b/lib/src/app/master_detail_page.dart
@@ -1,40 +1,31 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../../build_context_x.dart';
 import '../../common.dart';
 import '../../library.dart';
-import '../../player.dart';
 import '../../radio.dart';
 import '../../settings.dart';
 import '../../theme.dart';
 import '../globals.dart';
-import '../l10n/l10n.dart';
 import 'master_item.dart';
 
 class MasterDetailPage extends StatelessWidget {
   const MasterDetailPage({
     super.key,
     required this.setIndex,
-    required this.totalListAmount,
     required this.index,
     required this.masterItems,
     required this.libraryModel,
   });
 
   final void Function(int? value) setIndex;
-  final int totalListAmount;
   final int? index;
   final List<MasterItem> masterItems;
   final LibraryModel libraryModel;
 
   @override
   Widget build(BuildContext context) {
-    final playerModel = context.read<PlayerModel>();
-    final startPlaylist = playerModel.startPlaylist;
-    final pause = playerModel.pause;
-
     return YaruMasterDetailTheme(
       data: YaruMasterDetailTheme.of(context).copyWith(
         sideBarColor: getSideBarColor(context.t),
@@ -57,69 +48,22 @@ class MasterDetailPage extends StatelessWidget {
         ),
         breakpoint: 720,
         controller: YaruPageController(
-          length: totalListAmount,
+          length: masterItems.length,
           initialIndex: index ?? 0,
         ),
         tileBuilder: (context, index, selected, availableWidth) {
           final item = masterItems[index];
-          if (index == 3 || index == 5) {
-            return item.titleBuilder(context);
-          }
 
-          final isEnQueued = context.select(
-            (PlayerModel m) =>
-                m.queueName != null && m.queueName == item.content?.$1,
-          );
-          final isPlaying = context.select(
-            (PlayerModel m) => m.isPlaying,
-          );
-
-          final onPlay = item.content?.$1 == null || item.content?.$2 == null
-              ? null
-              : () {
-                  if (isEnQueued) {
-                    isPlaying ? pause() : playerModel.resume();
-                  } else {
-                    startPlaylist(
-                      audios: item.content!.$2,
-                      listName: item.content!.$1,
-                    );
-                  }
-                };
-
-          return Padding(
-            padding:
-                index == 0 ? const EdgeInsets.only(top: 5) : EdgeInsets.zero,
-            child: MasterTile(
-              iconData:
-                  isPlaying && isEnQueued ? Iconz().pause : Iconz().playFilled,
-              selected: index == 4 ? false : selected,
-              title: item.titleBuilder(context),
-              subtitle: item.subtitleBuilder?.call(context),
-              onPlay: onPlay,
-              leading: item.iconBuilder == null
-                  ? null
-                  : Padding(
-                      padding: index <= 3
-                          ? EdgeInsets.zero
-                          : const EdgeInsets.only(right: 4),
-                      child: item.iconBuilder!(
-                        context,
-                        selected,
-                      ),
-                    ),
-              onTap: index != 4
-                  ? null
-                  : () => showDialog(
-                        context: context,
-                        builder: (context) {
-                          return PlaylistDialog(
-                            playlistName: context.l10n.createNewPlaylist,
-                            allowCreate: true,
-                            libraryModel: libraryModel,
-                          );
-                        },
-                      ),
+          return MasterTile(
+            audios: item.content.$2,
+            pageId: item.content.$1,
+            libraryModel: libraryModel,
+            selected: selected,
+            title: item.titleBuilder(context),
+            subtitle: item.subtitleBuilder?.call(context),
+            leading: item.iconBuilder?.call(
+              context,
+              selected,
             ),
           );
         },

--- a/lib/src/app/master_item.dart
+++ b/lib/src/app/master_item.dart
@@ -8,12 +8,13 @@ class MasterItem {
     this.subtitleBuilder,
     required this.pageBuilder,
     this.iconBuilder,
-    this.content,
+    required this.content,
   });
 
   final WidgetBuilder titleBuilder;
   final WidgetBuilder? subtitleBuilder;
   final WidgetBuilder pageBuilder;
   final Widget Function(BuildContext context, bool selected)? iconBuilder;
-  final (String, Set<Audio>)? content;
+  // TODO: lookup Set for pageID instead of copying it
+  final (String, Set<Audio>) content;
 }

--- a/lib/src/app/master_items.dart
+++ b/lib/src/app/master_items.dart
@@ -27,6 +27,7 @@ List<MasterItem> createMasterItems({
       iconBuilder: (context, selected) => LocalAudioPageIcon(
         selected: selected,
       ),
+      content: (kLocalAudio, {}),
     ),
     MasterItem(
       titleBuilder: (context) => Text(context.l10n.radio),
@@ -38,6 +39,7 @@ List<MasterItem> createMasterItems({
       iconBuilder: (context, selected) => RadioPageIcon(
         selected: selected,
       ),
+      content: (kRadio, {}),
     ),
     MasterItem(
       titleBuilder: (context) => Text(context.l10n.podcasts),
@@ -50,29 +52,13 @@ List<MasterItem> createMasterItems({
       iconBuilder: (context, selected) => PodcastsPageIcon(
         selected: selected,
       ),
-    ),
-    MasterItem(
-      titleBuilder: (context) => const SpacedDivider(
-        top: 10,
-        bottom: 10,
-        right: 0,
-        left: 0,
-      ),
-      pageBuilder: (context) => const SizedBox.shrink(),
+      content: (kPodcasts, {}),
     ),
     MasterItem(
       iconBuilder: (context, selected) => Icon(Iconz().plus),
       titleBuilder: (context) => Text(context.l10n.playlistDialogTitleNew),
       pageBuilder: (context) => const SizedBox.shrink(),
-    ),
-    MasterItem(
-      titleBuilder: (context) => const SpacedDivider(
-        top: 10,
-        bottom: 10,
-        right: 0,
-        left: 0,
-      ),
-      pageBuilder: (context) => const SizedBox.shrink(),
+      content: (kNewPlaylist, {}),
     ),
     MasterItem(
       titleBuilder: (context) => Text(context.l10n.likedSongs),

--- a/lib/src/library/library_model.dart
+++ b/lib/src/library/library_model.dart
@@ -5,7 +5,7 @@ import 'package:safe_change_notifier/safe_change_notifier.dart';
 import '../../data.dart';
 import 'library_service.dart';
 
-const fix = 7;
+const kFixedListAmount = 5; // local, radio, podcasts, newplaylist, favs
 
 class LibraryModel extends SafeChangeNotifier {
   LibraryModel(this._service);
@@ -33,7 +33,7 @@ class LibraryModel extends SafeChangeNotifier {
 
   Future<void> init() async {
     if (_service.appIndex != null &&
-        totalListAmount - 1 >= _service.appIndex!) {
+        _totalListAmount - 1 >= _service.appIndex!) {
       _index = _service.appIndex;
     }
 
@@ -92,12 +92,12 @@ class LibraryModel extends SafeChangeNotifier {
     super.dispose();
   }
 
-  int get totalListAmount {
+  int get _totalListAmount {
     return starredStationsLength +
         podcastsLength +
         playlistsLength +
         pinnedAlbumsLength +
-        fix;
+        kFixedListAmount;
   }
 
   //
@@ -233,7 +233,7 @@ class LibraryModel extends SafeChangeNotifier {
     final playlist = getPlaylistById(id);
     if (playlist == null) return null;
     final allPlaylists = playlists.entries.map((e) => e.value).toList();
-    return fix + allPlaylists.indexOf(playlist);
+    return kFixedListAmount + allPlaylists.indexOf(playlist);
   }
 
   int? get localAudioindex => _service.localAudioIndex;

--- a/lib/src/local_audio/local_audio_page.dart
+++ b/lib/src/local_audio/local_audio_page.dart
@@ -265,6 +265,11 @@ class LocalAudioPageIcon extends StatelessWidget {
         color: theme.colorScheme.primary,
       );
     }
-    return selected ? Icon(Iconz().localAudioFilled) : Icon(Iconz().localAudio);
+
+    return Padding(
+      padding: kMainPageIconPadding,
+      child:
+          selected ? Icon(Iconz().localAudioFilled) : Icon(Iconz().localAudio),
+    );
   }
 }

--- a/lib/src/player/player_model.dart
+++ b/lib/src/player/player_model.dart
@@ -32,14 +32,6 @@ class PlayerModel extends SafeChangeNotifier {
   List<Audio> get queue => service.queue.$2;
   MpvMetaData? get mpvMetaData => service.mpvMetaData;
 
-  bool? _fullScreen;
-  bool? get fullScreen => _fullScreen;
-  void setFullScreen(bool? value) {
-    if (value == null || value == _fullScreen) return;
-    _fullScreen = value;
-    notifyListeners();
-  }
-
   Audio? get audio => service.audio;
 
   bool? get isVideo => service.isVideo;

--- a/lib/src/player/player_track.dart
+++ b/lib/src/player/player_track.dart
@@ -75,9 +75,13 @@ class PlayerTrack extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             RepaintBoundary(
-              child: Text(
-                formatTime(position ?? Duration.zero),
-                style: textStyle,
+              child: SizedBox(
+                width: 40,
+                height: 15,
+                child: Text(
+                  formatTime(position ?? Duration.zero),
+                  style: textStyle,
+                ),
               ),
             ),
           ],
@@ -92,9 +96,13 @@ class PlayerTrack extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             RepaintBoundary(
-              child: Text(
-                formatTime(duration ?? Duration.zero),
-                style: textStyle,
+              child: SizedBox(
+                width: 40,
+                height: 15,
+                child: Text(
+                  formatTime(duration ?? Duration.zero),
+                  style: textStyle,
+                ),
               ),
             ),
           ],

--- a/lib/src/player/player_view.dart
+++ b/lib/src/player/player_view.dart
@@ -57,13 +57,14 @@ class _PlayerViewState extends State<PlayerView> {
     final theme = context.t;
 
     final playerModel = context.read<PlayerModel>();
+    final appModel = context.read<AppModel>();
     final nextAudio = context.select((PlayerModel m) => m.nextAudio);
     final c = context.select((PlayerModel m) => m.color);
     final color = getPlayerBg(
       c,
       theme.isLight ? kCardColorLight : kCardColorDark,
     );
-    final setFullScreen = playerModel.setFullScreen;
+    final setFullScreen = appModel.setFullScreen;
     final playPrevious = playerModel.playPrevious;
     final playNext = playerModel.playNext;
     final audio = context.select((PlayerModel m) => m.audio);

--- a/lib/src/podcasts/podcasts_page.dart
+++ b/lib/src/podcasts/podcasts_page.dart
@@ -6,6 +6,7 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 import '../../app.dart';
 import '../../build_context_x.dart';
 import '../../common.dart';
+import '../../constants.dart';
 import '../../data.dart';
 import '../../player.dart';
 import '../../podcasts.dart';
@@ -236,6 +237,9 @@ class PodcastsPageIcon extends StatelessWidget {
       );
     }
 
-    return selected ? Icon(Iconz().podcastFilled) : Icon(Iconz().podcast);
+    return Padding(
+      padding: kMainPageIconPadding,
+      child: selected ? Icon(Iconz().podcastFilled) : Icon(Iconz().podcast),
+    );
   }
 }

--- a/lib/src/radio/radio_page.dart
+++ b/lib/src/radio/radio_page.dart
@@ -324,6 +324,9 @@ class RadioPageIcon extends StatelessWidget {
       );
     }
 
-    return selected ? Icon(Iconz().radioFilled) : Icon(Iconz().radio);
+    return Padding(
+      padding: kMainPageIconPadding,
+      child: selected ? Icon(Iconz().radioFilled) : Icon(Iconz().radio),
+    );
   }
 }


### PR DESCRIPTION
- move complicated build logic outside of master detail page
- give playertrack times height to avoid repaint of the whole app
- move fullscreen get/set to appmodel
- give all master items pageIDs