### PR TITLE
LocalAudio: sort artists and albums

### DIFF
--- a/lib/src/local_audio/local_audio_model.dart
+++ b/lib/src/local_audio/local_audio_model.dart
@@ -98,7 +98,12 @@ class LocalAudioModel extends SafeChangeNotifier {
         artistsResult.add(a);
       }
     }
-    return artistsResult;
+    final list = artistsResult.toList();
+    sortListByAudioFilter(
+      audioFilter: AudioFilter.artist,
+      audios: list,
+    );
+    return Set.from(list);
   }
 
   Set<Audio>? _allAlbums;
@@ -111,7 +116,12 @@ class LocalAudioModel extends SafeChangeNotifier {
         albumsResult.add(a);
       }
     }
-    return albumsResult;
+    final list = albumsResult.toList();
+    sortListByAudioFilter(
+      audioFilter: AudioFilter.album,
+      audios: list,
+    );
+    return Set.from(list);
   }
 
   AudioFilter _audioFilter = AudioFilter.title;


### PR DESCRIPTION
As a start sort AlbumView by Audio.album and ArtistView by Audio.artist

![Bildschirmfoto 2024-02-12 um 15 17 33](https://github.com/ubuntu-flutter-community/musicpod/assets/15329494/a2a67a98-f183-4797-bc0a-da9c3b363793)
![Bildschirmfoto 2024-02-12 um 15 17 45](https://github.com/ubuntu-flutter-community/musicpod/assets/15329494/8a040279-30b4-422c-ab3b-ee455f36a378)


Ref #503