### PR TITLE
Improve sorting of strings that contain numbers

### DIFF
--- a/lib/src/common/audio_filter.dart
+++ b/lib/src/common/audio_filter.dart
@@ -1,4 +1,5 @@
 import '../data/audio.dart';
+import 'package:intl/intl.dart';
 
 enum AudioFilter {
   trackNumber,
@@ -8,6 +9,20 @@ enum AudioFilter {
   genre,
   year,
   diskNumber;
+}
+
+int _compareStrings(String a, String b) {
+  final r = RegExp('\\d+');
+  final f = NumberFormat('0' * 16);
+  final aNew = a.replaceAllMapped(
+    r,
+    (match) => f.format(int.tryParse(match[0] ?? '0') ?? 0),
+  );
+  final bNew = b.replaceAllMapped(
+    r,
+    (match) => f.format(int.tryParse(match[0] ?? '0') ?? 0),
+  );
+  return aNew.compareTo(bNew);
 }
 
 void sortListByAudioFilter({
@@ -20,8 +35,8 @@ void sortListByAudioFilter({
       audios.sort((a, b) {
         if (a.artist != null && b.artist != null) {
           return descending
-              ? b.artist!.compareTo(a.artist!)
-              : a.artist!.compareTo(b.artist!);
+              ? _compareStrings(b.artist!, a.artist!)
+              : _compareStrings(a.artist!, b.artist!);
         }
         return 0;
       });
@@ -30,8 +45,8 @@ void sortListByAudioFilter({
       audios.sort((a, b) {
         if (a.title != null && b.title != null) {
           return descending
-              ? b.title!.compareTo(a.title!)
-              : a.title!.compareTo(b.title!);
+              ? _compareStrings(b.title!, a.title!)
+              : _compareStrings(a.title!, b.title!);
         }
         return 0;
       });
@@ -50,8 +65,8 @@ void sortListByAudioFilter({
       audios.sort((a, b) {
         if (a.album != null && b.album != null) {
           final albumComp = descending
-              ? b.album!.compareTo(a.album!)
-              : a.album!.compareTo(b.album!);
+              ? _compareStrings(b.album!, a.album!)
+              : _compareStrings(a.album!, b.album!);
           if (albumComp == 0 &&
               a.trackNumber != null &&
               b.trackNumber != null) {


### PR DESCRIPTION
When comparing strings that contain numbers, `compareTo` method gives results like `1, 10, 11, 2...`. This is technically correct, but unnatural.

I have to admit that my solution is not elegant, so I understand if this PR will be closed without merging, <del>but I couldn't think of anything better than replacing numbers with `a` and `b` characters in strings to compare if they both contain numbers.</del> (found another solution that I hope is better)

Before:

![1,10,2](https://github.com/ubuntu-flutter-community/musicpod/assets/117388856/8044b81d-dae3-4fc4-bdff-c08cf13c1939)

After:

![1,2,10](https://github.com/ubuntu-flutter-community/musicpod/assets/117388856/b9a91da2-5672-4d6a-9f50-8d2d73ed529f)

Related: #503 