### PR TITLE
Temp disable release github actions

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,11 +1,12 @@
 # TODO: fix AppImage release, see https://github.com/ubuntu-flutter-community/musicpod/issues/379
 # Apart from snap which is released via ci/cd pipeline to edge and then manually promoted from edge to stable
 # AppImage, Windows and MacOs releases should be created via this manual release action which is triggered when a tag is added to git
-name: Manual Release
+name: Release
 
 on:
   push:
-    branches: [  ]
+    branches:
+      - release
 
 env:
   FLUTTER_VERSION: '3.16.x'

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,8 +1,11 @@
-name: AppImage Release
+# TODO: fix AppImage release, see https://github.com/ubuntu-flutter-community/musicpod/issues/379
+# Apart from snap which is released via ci/cd pipeline to edge and then manually promoted from edge to stable
+# AppImage, Windows and MacOs releases should be created via this manual release action which is triggered when a tag is added to git
+name: Manual Release
 
 on:
   push:
-    branches: [ main ]
+    branches: [  ]
 
 env:
   FLUTTER_VERSION: '3.16.x'

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,9 +1,9 @@
-name: publish
+name: Publish Snap
 
 on:
   push:
     branches:
-      - main  
+      - snap  
 
 
 env:


### PR DESCRIPTION
- the snapcraft CD is reliable now for both amd64 and arm64, thus disabling snap build/publish on main push, as this is automatically taken care of by snapcraft
- disabled appimage action, to make a new github action in the future which is triggered by a git tag and then creates appimage, exe and dmg artifacts