### PR TITLE
Wrap sidebar player divider in material

### DIFF
--- a/lib/src/player/player_view.dart
+++ b/lib/src/player/player_view.dart
@@ -65,9 +65,7 @@ class _PlayerViewState extends ConsumerState<PlayerView> {
     if (widget.mode != PlayerViewMode.bottom) {
       player = Row(
         children: [
-          VerticalDivider(
-            color: theme.colorScheme.onSurface.withOpacity(0.005),
-          ),
+          const Material(child: VerticalDivider()),
           Expanded(
             child: FullHeightPlayer(
               isVideo: isVideo == true,


### PR DESCRIPTION
otherwise the window background shines through, which is different on each platform