### PR TITLE
Fix MusicPod breaking  when network manager not available on linux 

### DIFF
--- a/lib/src/app/app_model.dart
+++ b/lib/src/app/app_model.dart
@@ -28,7 +28,11 @@ class AppModel extends SafeChangeNotifier {
   Future<void> init() async {
     _subscription ??=
         _connectivity.onConnectivityChanged.listen(_updateConnectivity);
-    return _connectivity.checkConnectivity().then(_updateConnectivity);
+
+    return _connectivity
+        .checkConnectivity()
+        .then(_updateConnectivity)
+        .catchError((e) => _updateConnectivity([ConnectivityResult.none]));
   }
 
   @override

--- a/lib/src/app/app_model.dart
+++ b/lib/src/app/app_model.dart
@@ -32,7 +32,7 @@ class AppModel extends SafeChangeNotifier {
     return _connectivity
         .checkConnectivity()
         .then(_updateConnectivity)
-        .catchError((e) => _updateConnectivity([ConnectivityResult.none]));
+        .catchError((e) => _updateConnectivity([ConnectivityResult.wifi]));
   }
 
   @override


### PR DESCRIPTION
Added error checking to the connectivity check function otherwise the function never returns breaking parts of the app if network manager is not on the system. This makes MusicPod work as normal without network manager except it will think it is offline.