### PR TITLE
Init local audio model early

### DIFF
--- a/lib/src/app/app.dart
+++ b/lib/src/app/app.dart
@@ -12,6 +12,7 @@ import '../../get.dart';
 import '../../library.dart';
 import '../../theme.dart';
 import '../l10n/l10n.dart';
+import '../local_audio/local_audio_model.dart';
 import '../settings/settings_model.dart';
 import 'view/scaffold.dart';
 
@@ -120,11 +121,15 @@ class _MusicPodAppState extends State<_MusicPodApp>
       );
     }
 
-    final appModel = getIt<AppModel>();
     await getIt<LibraryModel>().init();
+    // Note: if users have small local audio libs this will hardly be visible
+    // if users have huge local libs they will probably use MusicPod a lot
+    // for local audios and will land here sooner or later.
+    // So do this right away to avoid an uninitialized LocalAudioModel
+    await getIt<LocalAudioModel>().init();
 
     if (!mounted) return false;
-    await appModel.init();
+    await getIt<AppModel>().init();
 
     getIt<ExternalPathService>().init();
 

--- a/lib/src/local_audio/local_audio_model.dart
+++ b/lib/src/local_audio/local_audio_model.dart
@@ -269,18 +269,16 @@ class LocalAudioModel extends SafeChangeNotifier {
     return images;
   }
 
+  List<String>? _failedImports;
+  List<String>? get failedImports => _failedImports;
+
   Future<void> init({
-    required void Function(List<String> failedImports) onFail,
     bool forceInit = false,
   }) async {
     if (forceInit ||
         (_localAudioService.audios == null ||
             _localAudioService.audios?.isEmpty == true)) {
-      final failedImports = await _localAudioService.init();
-
-      if (failedImports.isNotEmpty) {
-        onFail(failedImports);
-      }
+      _failedImports = await _localAudioService.init();
 
       _titles = _findAllTitles();
       _allAlbums = findAllAlbums();

--- a/lib/src/local_audio/view/failed_imports_content.dart
+++ b/lib/src/local_audio/view/failed_imports_content.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 
 import '../../../build_context_x.dart';
+import '../../../get.dart';
+import '../../common/snackbars.dart';
 import '../../l10n/l10n.dart';
+import '../../settings/settings_model.dart';
 
 class FailedImportsContent extends StatelessWidget {
   const FailedImportsContent({
@@ -68,4 +71,21 @@ class FailedImportsContent extends StatelessWidget {
       ),
     );
   }
+}
+
+ScaffoldFeatureController<SnackBar, SnackBarClosedReason>?
+    showFailedImportsSnackBar({
+  required List<String> failedImports,
+  required BuildContext context,
+}) {
+  final settingsModel = getIt<SettingsModel>();
+  if (settingsModel.neverShowFailedImports) return null;
+  return showSnackBar(
+    context: context,
+    content: FailedImportsContent(
+      failedImports: failedImports,
+      onNeverShowFailedImports: () =>
+          settingsModel.setNeverShowFailedImports(true),
+    ),
+  );
 }

--- a/lib/src/local_audio/view/local_audio_page.dart
+++ b/lib/src/local_audio/view/local_audio_page.dart
@@ -1,6 +1,5 @@
 import 'package:animated_emoji/animated_emoji.dart';
 import 'package:flutter/material.dart';
-
 import 'package:yaru/yaru.dart';
 
 import '../../../app.dart';
@@ -14,15 +13,12 @@ import '../../../local_audio.dart';
 import '../../../player.dart';
 import '../../l10n/l10n.dart';
 import '../../library/library_model.dart';
-import '../../settings/settings_model.dart';
 import 'local_audio_body.dart';
 import 'local_audio_control_panel.dart';
 import 'local_audio_view.dart';
 
 class LocalAudioPage extends StatefulWidget with WatchItStatefulWidgetMixin {
-  const LocalAudioPage({
-    super.key,
-  });
+  const LocalAudioPage({super.key});
 
   @override
   State<LocalAudioPage> createState() => _LocalAudioPageState();
@@ -32,29 +28,13 @@ class _LocalAudioPageState extends State<LocalAudioPage> {
   @override
   void initState() {
     super.initState();
-    final model = getIt<LocalAudioModel>();
-    final settingsModel = getIt<SettingsModel>();
-
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      if (!mounted) return;
-      model.init(
-        onFail: (failedImports) {
-          if (!mounted || settingsModel.neverShowFailedImports) {
-            return;
-          }
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              duration: const Duration(seconds: 10),
-              content: FailedImportsContent(
-                onNeverShowFailedImports: () =>
-                    settingsModel.setNeverShowFailedImports(true),
-                failedImports: failedImports,
-              ),
-            ),
-          );
-        },
+    final failedImports = getIt<LocalAudioModel>().failedImports;
+    if (mounted && failedImports?.isNotEmpty == true) {
+      showFailedImportsSnackBar(
+        failedImports: failedImports!,
+        context: context,
       );
-    });
+    }
   }
 
   @override

--- a/lib/src/player/player_mixin.dart
+++ b/lib/src/player/player_mixin.dart
@@ -62,37 +62,23 @@ mixin PlayerMixin {
 
   void _onLocalAudioTitleTap({required Audio audio}) {
     final localAudioModel = getIt<LocalAudioModel>();
-    localAudioModel
-        .init(
-      onFail: (failedImports) {},
-    )
-        .then((_) {
-      final libraryModel = getIt<LibraryModel>();
-      int? index = libraryModel.indexOfAlbum(audio.albumId);
-      if (index != null) {
-        navigatorKey.currentState
-            ?.maybePop()
-            .then((value) => libraryModel.setIndex(index));
-      } else {
-        final albumAudios = localAudioModel.findAlbum(audio);
-        if (albumAudios?.firstOrNull == null) return;
-        final id = albumAudios!.first.albumId;
-        if (id == null) return;
+    final albumAudios = localAudioModel.findAlbum(audio);
+    if (albumAudios?.firstOrNull == null) return;
+    final id = albumAudios!.first.albumId;
+    if (id == null) return;
 
-        getIt<AppModel>().setFullScreen(false);
+    getIt<AppModel>().setFullScreen(false);
 
-        navigatorKey.currentState?.push(
-          MaterialPageRoute(
-            builder: (context) {
-              return AlbumPage(
-                id: id,
-                album: albumAudios,
-              );
-            },
-          ),
-        );
-      }
-    });
+    navigatorKey.currentState?.push(
+      MaterialPageRoute(
+        builder: (context) {
+          return AlbumPage(
+            id: id,
+            album: albumAudios,
+          );
+        },
+      ),
+    );
   }
 
   void onArtistTap({required Audio audio, required BuildContext context}) {
@@ -157,26 +143,20 @@ mixin PlayerMixin {
 
   void _onLocalAudioArtistTap({required Audio audio}) {
     final localAudioModel = getIt<LocalAudioModel>();
-    localAudioModel
-        .init(
-      onFail: (failedImports) {},
-    )
-        .then((_) {
-      final artistAudios = localAudioModel.findArtist(audio);
-      if (artistAudios?.firstOrNull == null) return;
-      final images = localAudioModel.findImages(artistAudios ?? {});
-      getIt<AppModel>().setFullScreen(false);
+    final artistAudios = localAudioModel.findArtist(audio);
+    if (artistAudios?.firstOrNull == null) return;
+    final images = localAudioModel.findImages(artistAudios ?? {});
+    getIt<AppModel>().setFullScreen(false);
 
-      navigatorKey.currentState?.push(
-        MaterialPageRoute(
-          builder: (context) {
-            return ArtistPage(
-              artistAudios: artistAudios,
-              images: images,
-            );
-          },
-        ),
-      );
-    });
+    navigatorKey.currentState?.push(
+      MaterialPageRoute(
+        builder: (context) {
+          return ArtistPage(
+            artistAudios: artistAudios,
+            images: images,
+          );
+        },
+      ),
+    );
   }
 }

--- a/lib/src/settings/view/settings_page.dart
+++ b/lib/src/settings/view/settings_page.dart
@@ -219,22 +219,7 @@ class _LocalAudioSection extends StatelessWidget with WatchItMixin {
 
     Future<void> onDirectorySelected(String? directoryPath) async {
       settingsModel.setDirectory(directoryPath).then(
-            (value) async => await localAudioModel.init(
-              forceInit: true,
-              onFail: (failedImports) {
-                if (settingsModel.neverShowFailedImports) return;
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    duration: const Duration(seconds: 10),
-                    content: FailedImportsContent(
-                      failedImports: failedImports,
-                      onNeverShowFailedImports: () =>
-                          settingsModel.setNeverShowFailedImports(true),
-                    ),
-                  ),
-                );
-              },
-            ),
+            (_) async => await localAudioModel.init(forceInit: true),
           );
     }
 


### PR DESCRIPTION
If users have small local audio libs this will hardly be visible. If users have huge local libs they will probably use MusicPod a lot for local audios and will land here sooner or later. So do this right away to avoid an uninitialized LocalAudioModel.