### PR TITLE
Player service improvements

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,7 +1,83 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- The INTERNET permission is required for development. Specifically,
-         the Flutter tool needs it to communicate with the running application
-         to allow setting breakpoints, to provide hot reload, etc.
-    -->
-    <uses-permission android:name="android.permission.INTERNET"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <!--
+      Internet access permissions.
+      -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <!--
+        Media access permissions.
+        Android 13 or higher.
+        https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions
+        -->
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- ALSO ADD THIS PERMISSION IF TARGETING SDK 34 -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <!-- Permissions options for the `storage` group -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- Read storage permission for Android 12 and lower -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
+    <!-- Permissions options for the `manage external storage` group -->
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+
+    <!-- Permissions options for the `access notification policy` group -->
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
+
+
+    <!-- Permissions options for the `notification` group -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application
+        android:label="musicpod"
+        android:name="${applicationName}"
+        android:icon="@mipmap/ic_launcher">
+
+        <activity
+            android:name="com.ryanheise.audioservice.AudioServiceActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:hardwareAccelerated="true"
+            android:windowSoftInputMode="adjustResize">
+            <!-- Specifies an Android theme to apply to this Activity as soon as
+                 the Android process has started. This theme is visible to the user
+                 while the Flutter UI initializes. After that, this theme continues
+                 to determine the Window background behind the Flutter UI. -->
+            <meta-data
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"
+            />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <!-- ADD THIS "SERVICE" element -->
+        <service android:name="com.ryanheise.audioservice.AudioService"
+            android:foregroundServiceType="mediaPlayback"
+            android:exported="true" tools:ignore="Instantiatable">
+            <intent-filter>
+                <action android:name="android.media.browse.MediaBrowserService" />
+            </intent-filter>
+        </service>
+
+        <!-- ADD THIS "RECEIVER" element -->
+        <receiver android:name="com.ryanheise.audioservice.MediaButtonReceiver"
+            android:exported="true" tools:ignore="Instantiatable">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
+        <!-- Don't delete the meta-data below.
+             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
+    </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
     <!--
       Internet access permissions.
       -->
@@ -13,6 +13,8 @@
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- ALSO ADD THIS PERMISSION IF TARGETING SDK 34 -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
     <!-- Permissions options for the `storage` group -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <!-- Read storage permission for Android 12 and lower -->
@@ -55,22 +57,22 @@
             </intent-filter>
         </activity>
 
-        <!-- ADD THIS "SERVICE" element -->
+       <!-- ADD THIS "SERVICE" element -->
         <service android:name="com.ryanheise.audioservice.AudioService"
-            android:foregroundServiceType="mediaPlayback"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.media.browse.MediaBrowserService" />
-            </intent-filter>
+        android:foregroundServiceType="mediaPlayback"
+        android:exported="true" tools:ignore="Instantiatable">
+        <intent-filter>
+            <action android:name="android.media.browse.MediaBrowserService" />
+        </intent-filter>
         </service>
 
         <!-- ADD THIS "RECEIVER" element -->
         <receiver android:name="com.ryanheise.audioservice.MediaButtonReceiver"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MEDIA_BUTTON" />
-            </intent-filter>
-        </receiver>
+            android:exported="true" tools:ignore="Instantiatable">
+        <intent-filter>
+            <action android:name="android.intent.action.MEDIA_BUTTON" />
+        </intent-filter>
+        </receiver> 
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/lib/src/player/player_model.dart
+++ b/lib/src/player/player_model.dart
@@ -38,9 +38,9 @@ class PlayerModel extends SafeChangeNotifier {
   StreamSubscription<bool>? _lastPositionsSub;
   StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
 
-  String? get queueName => _service.queue.$1;
+  String? get queueName => _service.queue.name;
 
-  List<Audio> get queue => _service.queue.$2;
+  List<Audio> get queue => _service.queue.audios;
   MpvMetaData? get mpvMetaData => _service.mpvMetaData;
 
   Audio? get audio => _service.audio;
@@ -194,12 +194,9 @@ class PlayerModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
-  void safeLastPosition() => _service.safeLastPosition();
-
   Map<String, Duration>? get lastPositions => _service.lastPositions;
   Duration? getLastPosition(String? url) => _service.getLastPosition(url);
-  void addLastPosition(String url, Duration lastPosition) =>
-      _service.addLastPosition(url, lastPosition);
+  Future<void> safeLastPosition() => _service.safeLastPosition();
 
   Map<String, MpvMetaData> get radioHistory => _service.radioHistory;
 

--- a/lib/src/player/player_service.dart
+++ b/lib/src/player/player_service.dart
@@ -19,6 +19,8 @@ import '../../string_x.dart';
 import '../../persistence_utils.dart';
 import '../../theme.dart';
 
+typedef Queue = ({String name, List<Audio> audios});
+
 class PlayerService {
   PlayerService({
     required this.controller,
@@ -45,10 +47,10 @@ class PlayerService {
 
   final _queueController = StreamController<bool>.broadcast();
   Stream<bool> get queueChanged => _queueController.stream;
-  (String, List<Audio>) _queue = ('', []);
-  (String, List<Audio>) get queue => _queue;
-  void setQueue((String, List<Audio>) value) {
-    if (value == _queue || value.$2.isEmpty) return;
+  Queue _queue = (name: '', audios: []);
+  Queue get queue => _queue;
+  void setQueue(Queue value) {
+    if (value == _queue || value.audios.isEmpty) return;
     _queue = value;
     _queueController.add(true);
   }
@@ -176,7 +178,7 @@ class PlayerService {
   void setShuffle(bool value) {
     if (value == _shuffle) return;
     _shuffle = value;
-    if (value && queue.$2.length > 1) {
+    if (value && queue.audios.length > 1) {
       _randomNext();
     }
     _shuffleController.add(true);
@@ -279,7 +281,11 @@ class PlayerService {
 
     _isCompletedSub = _player.stream.completed.listen((value) async {
       if (value) {
-        await playNext();
+        if (_queue.audios.length > 1) {
+          await playNext();
+        }
+      } else {
+        await safeLastPosition();
       }
     });
 
@@ -328,11 +334,11 @@ class PlayerService {
       }
     });
 
-    await _readPlayerState();
+    await _setPlayerState();
   }
 
   Future<void> playNext() async {
-    safeLastPosition();
+    await safeLastPosition();
     if (!repeatSingle && nextAudio != null) {
       _setAudio(nextAudio!);
       _estimateNext();
@@ -341,23 +347,23 @@ class PlayerService {
   }
 
   void insertIntoQueue(Audio newAudio) {
-    if (_queue.$2.isNotEmpty &&
-        !_queue.$2.contains(newAudio) &&
+    if (_queue.audios.isNotEmpty &&
+        !_queue.audios.contains(newAudio) &&
         _audio != null) {
-      final currentIndex = queue.$2.indexOf(_audio!);
-      _queue.$2.insert(currentIndex + 1, newAudio);
+      final currentIndex = queue.audios.indexOf(_audio!);
+      _queue.audios.insert(currentIndex + 1, newAudio);
       nextAudio = newAudio;
     }
   }
 
   void moveAudioInQueue(int oldIndex, int newIndex) {
-    if (_queue.$2.isNotEmpty && newIndex < _queue.$2.length) {
+    if (_queue.audios.isNotEmpty && newIndex < _queue.audios.length) {
       if (oldIndex < newIndex) {
         newIndex -= 1;
       }
 
-      final audio = _queue.$2.removeAt(oldIndex);
-      _queue.$2.insert(newIndex, audio);
+      final audio = _queue.audios.removeAt(oldIndex);
+      _queue.audios.insert(newIndex, audio);
 
       _estimateNext();
 
@@ -366,7 +372,7 @@ class PlayerService {
   }
 
   void remove(Audio deleteMe) {
-    _queue.$2.remove(deleteMe);
+    _queue.audios.remove(deleteMe);
     _estimateNext();
     _queueController.add(true);
   }
@@ -374,16 +380,16 @@ class PlayerService {
   void _estimateNext() {
     if (audio == null) return;
 
-    if (queue.$2.isNotEmpty == true && queue.$2.contains(audio)) {
-      final currentIndex = queue.$2.indexOf(audio!);
+    if (queue.audios.isNotEmpty && queue.audios.contains(audio)) {
+      final currentIndex = queue.audios.indexOf(audio!);
 
-      if (shuffle && queue.$2.length > 1) {
+      if (shuffle && queue.audios.length > 1) {
         _randomNext();
       } else {
-        if (currentIndex == queue.$2.length - 1) {
-          nextAudio = queue.$2.elementAt(0);
+        if (currentIndex == queue.audios.length - 1) {
+          nextAudio = queue.audios.elementAt(0);
         } else {
-          nextAudio = queue.$2.elementAt(queue.$2.indexOf(audio!) + 1);
+          nextAudio = queue.audios.elementAt(queue.audios.indexOf(audio!) + 1);
         }
       }
     }
@@ -391,29 +397,29 @@ class PlayerService {
 
   void _randomNext() {
     if (audio == null) return;
-    final currentIndex = queue.$2.indexOf(audio!);
-    final max = queue.$2.length;
+    final currentIndex = queue.audios.indexOf(audio!);
+    final max = queue.audios.length;
     final random = Random();
     var randomIndex = random.nextInt(max);
     while (randomIndex == currentIndex) {
       randomIndex = random.nextInt(max);
     }
-    nextAudio = queue.$2.elementAt(randomIndex);
+    nextAudio = queue.audios.elementAt(randomIndex);
   }
 
   Future<void> playPrevious() async {
-    if (queue.$2.isNotEmpty == true &&
+    if (queue.audios.isNotEmpty == true &&
         audio != null &&
-        queue.$2.contains(audio)) {
+        queue.audios.contains(audio)) {
       if (position != null && position!.inSeconds > 10) {
         setPosition(Duration.zero);
         await seek();
       } else {
-        final currentIndex = queue.$2.indexOf(audio!);
+        final currentIndex = queue.audios.indexOf(audio!);
         if (currentIndex == 0) {
           return;
         }
-        final mightBePrevious = queue.$2.elementAtOrNull(currentIndex - 1);
+        final mightBePrevious = queue.audios.elementAtOrNull(currentIndex - 1);
         if (mightBePrevious == null) return;
         _setAudio(mightBePrevious);
         _estimateNext();
@@ -427,12 +433,12 @@ class PlayerService {
     required String listName,
     int? index,
   }) async {
-    if (listName == _queue.$1 &&
+    if (listName == _queue.name &&
         index != null &&
         audios.elementAtOrNull(index) != null) {
       _setAudio(audios.elementAtOrNull(index)!);
     } else {
-      setQueue((listName, audios.toList()));
+      setQueue((name: listName, audios: audios.toList()));
       _setAudio(
         (index != null && audios.elementAtOrNull(index) != null)
             ? audios.elementAtOrNull(index)!
@@ -471,8 +477,8 @@ class PlayerService {
     _color = generator.dominantColor?.color;
   }
 
-  Future<void> _readPlayerState() async {
-    final playerState = await readPlayerState();
+  Future<void> _setPlayerState() async {
+    final playerState = await _readPlayerState();
 
     _lastPositions = (await getSettings(kLastPositionsFileName)).map(
       (key, value) => MapEntry(key, value.parsedDuration ?? Duration.zero),
@@ -490,7 +496,7 @@ class PlayerService {
 
       if (playerState.queue?.isNotEmpty == true &&
           playerState.queueName?.isNotEmpty == true) {
-        setQueue((playerState.queueName!, playerState.queue!));
+        setQueue((name: playerState.queueName!, audios: playerState.queue!));
       }
 
       if (playerState.volume != null) {
@@ -510,25 +516,23 @@ class PlayerService {
   Map<String, Duration> get lastPositions => _lastPositions;
   final _lastPositionsController = StreamController<bool>.broadcast();
   Stream<bool> get lastPositionsChanged => _lastPositionsController.stream;
-  void addLastPosition(String url, Duration lastPosition) {
-    writeSetting(url, lastPosition.toString(), kLastPositionsFileName)
-        .then((_) {
-      if (_lastPositions.containsKey(url) == true) {
-        _lastPositions.update(url, (value) => lastPosition);
-      } else {
-        _lastPositions.putIfAbsent(url, () => lastPosition);
-      }
-      _lastPositionsController.add(true);
-    });
+  Future<void> addLastPosition(String url, Duration lastPosition) async {
+    await writeSetting(url, lastPosition.toString(), kLastPositionsFileName);
+    if (_lastPositions.containsKey(url) == true) {
+      _lastPositions.update(url, (value) => lastPosition);
+    } else {
+      _lastPositions.putIfAbsent(url, () => lastPosition);
+    }
+    _lastPositionsController.add(true);
   }
 
   Duration? getLastPosition(String? url) => _lastPositions[url];
 
-  void safeLastPosition() {
+  Future<void> safeLastPosition() async {
     if (_audio?.audioType == AudioType.radio ||
         _audio?.url == null ||
         _position == null) return;
-    addLastPosition(_audio!.url!, _position!);
+    await addLastPosition(_audio!.url!, _position!);
   }
 
   Future<void> _initMediaControl() async {
@@ -670,7 +674,7 @@ class PlayerService {
 
   List<MediaControl> _determineMediaControls(bool playing) {
     final showSkipControls =
-        _queue.$2.isNotEmpty && _audio?.audioType != AudioType.radio;
+        _queue.audios.isNotEmpty && _audio?.audioType != AudioType.radio;
 
     final showSeekControls = _audio?.audioType == AudioType.podcast &&
         (Platform.isMacOS || Platform.isAndroid);
@@ -696,6 +700,9 @@ class PlayerService {
         title: audio.title ?? kAppTitle,
         artist: audio.artist ?? '',
         artUri: artUri,
+        duration: audio.durationMs == null
+            ? null
+            : Duration(milliseconds: audio.durationMs!.toInt()),
       ),
     );
   }
@@ -733,7 +740,7 @@ class PlayerService {
   }
 
   Future<void> dispose() async {
-    await writePlayerState();
+    await _writePlayerState();
     await _smtcSub?.cancel();
     await _smtc?.disableSmtc();
     await _smtc?.dispose();
@@ -762,20 +769,21 @@ class PlayerService {
     await _player.dispose();
   }
 
-  Future<void> writePlayerState() async {
+  Future<void> _writePlayerState() async {
     final playerState = PlayerState(
       audio: _audio,
       duration: _duration?.toString(),
       position: _position?.toString(),
-      queue: _queue.$2.take(100).toList(),
-      queueName: _queue.$1,
+      queue:
+          _queue.audios.length <= 100 ? _queue.audios.take(100).toList() : null,
+      queueName: _queue.audios.length <= 100 ? _queue.name : null,
       volume: _volume.toString(),
     );
 
     await writeJsonToFile(playerState.toMap(), kPlayerStateFileName);
   }
 
-  Future<PlayerState?> readPlayerState() async {
+  Future<PlayerState?> _readPlayerState() async {
     try {
       final workingDir = await getWorkingDir();
       final file = File(p.join(workingDir, kPlayerStateFileName));

--- a/lib/src/podcasts/view/audio_progress.dart
+++ b/lib/src/podcasts/view/audio_progress.dart
@@ -31,7 +31,7 @@ class AudioProgress extends StatelessWidget with WatchItMixin {
             : duration) ??
         Duration.zero;
 
-    bool sliderActive = dur.inSeconds > pos.inSeconds;
+    bool sliderActive = dur.inSeconds >= pos.inSeconds;
 
     return RepaintBoundary(
       child: SizedBox(

--- a/lib/src/podcasts/view/avatar_with_progress.dart
+++ b/lib/src/podcasts/view/avatar_with_progress.dart
@@ -26,12 +26,8 @@ class AvatarWithProgress extends StatelessWidget {
   final bool isPlayerPlaying;
   final void Function() pause;
   final Future<void> Function() resume;
-  final void Function() safeLastPosition;
-  final Future<void> Function({
-    required Set<Audio> audios,
-    required String listName,
-    int? index,
-  }) startPlaylist;
+  final Future<void> Function() safeLastPosition;
+  final void Function()? startPlaylist;
   final void Function()? removeUpdate;
 
   @override
@@ -71,11 +67,10 @@ class AvatarWithProgress extends StatelessWidget {
                   resume();
                 }
               } else {
-                safeLastPosition();
-                if (audio.website != null) {
-                  startPlaylist(audios: {audio}, listName: audio.website!);
-                }
-                removeUpdate?.call();
+                safeLastPosition().then((value) {
+                  startPlaylist?.call();
+                  removeUpdate?.call();
+                });
               }
             },
           ),

--- a/lib/src/podcasts/view/podcast_audio_tile.dart
+++ b/lib/src/podcasts/view/podcast_audio_tile.dart
@@ -40,13 +40,9 @@ class PodcastAudioTile extends StatelessWidget {
   final bool selected;
   final void Function() pause;
   final Future<void> Function() resume;
-  final Future<void> Function({
-    required Set<Audio> audios,
-    required String listName,
-    int? index,
-  }) startPlaylist;
+  final void Function()? startPlaylist;
   final void Function()? removeUpdate;
-  final void Function() safeLastPosition;
+  final Future<void> Function() safeLastPosition;
   final void Function()? addPodcast;
   final void Function()? insertIntoQueue;
 

--- a/lib/src/podcasts/view/sliver_podcast_page_list.dart
+++ b/lib/src/podcasts/view/sliver_podcast_page_list.dart
@@ -47,7 +47,11 @@ class SliverPodcastPageList extends StatelessWidget with WatchItMixin {
             selected: episode == selectedAudio,
             pause: playerModel.pause,
             resume: playerModel.resume,
-            startPlaylist: playerModel.startPlaylist,
+            startPlaylist: () => playerModel.startPlaylist(
+              audios: audios,
+              listName: pageId,
+              index: index,
+            ),
             lastPosition: playerModel.getLastPosition(episode.url),
             safeLastPosition: playerModel.safeLastPosition,
             isOnline: isOnline,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.18.13"
+  audio_service_mpris:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: b15f72e5ff26af00a986dc127bec23c616a3c4bb
+      resolved-ref: b15f72e5ff26af00a986dc127bec23c616a3c4bb
+      url: "https://github.com/Feichtmeier/audio-service-mpris"
+    source: git
+    version: "0.1.3"
   audio_service_platform_interface:
     dependency: transitive
     description:
@@ -105,14 +114,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.19"
-  base_x:
-    dependency: transitive
-    description:
-      name: base_x
-      sha256: "519abcdafd637d4b6bd7e72fabd8f9264935f804b9b9f6c5d8411c7d52cbf8fd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   basic_utils:
     dependency: "direct main"
     description:
@@ -911,15 +912,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.4"
-  mpris_service:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: "3a4a721"
-      resolved-ref: "3a4a72140087d3df130271c9213e61fa413d5740"
-      url: "https://github.com/alexmercerind/mpris_service"
-    source: git
-    version: "1.0.0"
   nm:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,10 @@ dependencies:
   animated_emoji: ^3.1.0
   audio_metadata_reader: ^0.0.6
   audio_service: ^0.18.12
+  audio_service_mpris:
+    git:
+      url: https://github.com/Feichtmeier/audio-service-mpris
+      ref: b15f72e5ff26af00a986dc127bec23c616a3c4bb
   basic_utils: ^5.7.0
   blur: ^3.1.0
   cached_network_image: ^3.3.1
@@ -47,10 +51,7 @@ dependencies:
   mime: ^1.0.5
   mime_type: ^1.0.0
   mockito: ^5.4.4
-  mpris_service:
-    git:
-      url: https://github.com/alexmercerind/mpris_service
-      ref: 3a4a721
+ 
   package_info_plus: ^8.0.0
   palette_generator: ^0.3.3+3
   path: ^1.9.0


### PR DESCRIPTION
- use audio_service_mpris instead of the mpris pub library
- fix last positions not being saved
- enqueue more podcasts on a single tile click
- change macOS & android audio controls depending on podcast/radio/local

Fixes #774