### PR TITLE
Shrink double apostrophe's.

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -101,7 +101,7 @@
     "queue": "Queue",
     "limit": "Limit",
     "decreaseSearchLimit": "Please decrease the search limit for",
-    "podcastFeedIsEmpty": "Sorry, this podcast''s feed is empty.",
+    "podcastFeedIsEmpty": "Sorry, this podcast's feed is empty.",
     "video": "Video",
     "ok": "OK",
     "noLocalTitlesFound": "It looks like your local music collection is empty. Check your library location in the settings.",
@@ -112,7 +112,7 @@
     "musicPodSubTitle": "Your Music, Radio and Podcast Player",
     "pickMusicCollection": "Pick your music collection",
     "newEpisode": "New",
-    "dontShowAgain": "Don''t show again",
+    "dontShowAgain": "Don't show again",
     "queueConfirmMessage": "Do you really want to enqueue {length} medias?",
     "@queueConfirmMessage": {
         "placeholders": {


### PR DESCRIPTION
In two messages, there's a double apostrophe. 
This gets rendered in the UI, which looks wrong. 
I hope me 'fixing' this isn't breaking 'escaping' anything.

![Screenshot 2024-07-15 at 15 17 37](https://github.com/user-attachments/assets/3ed1372d-e146-4148-bb50-cafcb968ab6b)
