### PR TITLE
Add animation effects to the dialog.

### DIFF
--- a/lib/app/view/master_detail_page.dart
+++ b/lib/app/view/master_detail_page.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_animated_dialog/flutter_animated_dialog.dart';
 import 'package:watch_it/watch_it.dart';
 import 'package:yaru/yaru.dart';
 
@@ -134,8 +135,9 @@ class MasterPanel extends StatelessWidget {
                 return MasterTile(
                   onTap: () {
                     if (item.pageId == kNewPlaylistPageId) {
-                      showDialog(
+                      showAnimatedDialog(
                         context: context,
+                        animationType: DialogTransitionType.fade,
                         builder: (context) {
                           return const ManualAddDialog();
                         },

--- a/lib/common/view/audio_page_header_html_description.dart
+++ b/lib/common/view/audio_page_header_html_description.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_animated_dialog/flutter_animated_dialog.dart';
+
 import '../../constants.dart';
 import '../../extensions/build_context_x.dart';
 import 'package:flutter/material.dart';
@@ -27,8 +29,9 @@ class AudioPageHeaderHtmlDescription extends StatelessWidget {
         width: kAudioHeaderDescriptionWidth,
         child: InkWell(
           borderRadius: BorderRadius.circular(kButtonRadius),
-          onTap: () => showDialog(
+          onTap: () => showAnimatedDialog(
             context: context,
+            animationType: DialogTransitionType.fade,
             builder: (context) => SimpleDialog(
               titlePadding: EdgeInsets.zero,
               contentPadding: EdgeInsets.zero,

--- a/lib/common/view/audio_tile_option_button.dart
+++ b/lib/common/view/audio_tile_option_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animated_dialog/flutter_animated_dialog.dart';
 import 'package:yaru/yaru.dart';
 
 import '../../extensions/build_context_x.dart';
@@ -64,8 +65,9 @@ class AudioTileOptionButton extends StatelessWidget {
               ),
             ),
           PopupMenuItem(
-            onTap: () => showDialog(
+            onTap: () => showAnimatedDialog(
               context: context,
+              animationType: DialogTransitionType.fade,
               builder: (context) {
                 return AddToPlaylistDialog(
                   audio: audio,
@@ -81,7 +83,8 @@ class AudioTileOptionButton extends StatelessWidget {
             ),
           ),
           PopupMenuItem(
-            onTap: () => showDialog(
+            onTap: () => showAnimatedDialog(
+              animationType: DialogTransitionType.fade,
               context: context,
               builder: (context) {
                 return MetaDataDialog(audio: audio);

--- a/lib/common/view/icy_image.dart
+++ b/lib/common/view/icy_image.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animated_dialog/flutter_animated_dialog.dart';
 
 import '../../common/view/icons.dart';
 import '../../constants.dart';
@@ -56,8 +57,9 @@ class _IcyImageState extends State<IcyImage> {
         borderRadius: bR,
         child: InkWell(
           borderRadius: bR,
-          onTap: () => showDialog(
+          onTap: () => showAnimatedDialog(
             context: context,
+            animationType: DialogTransitionType.fade,
             builder: (context) {
               final image = UrlStore().get(widget.mpvMetaData.icyTitle);
               return MpvMetadataDialog(

--- a/lib/local_audio/view/local_audio_page.dart
+++ b/lib/local_audio/view/local_audio_page.dart
@@ -1,5 +1,6 @@
 import 'package:animated_emoji/animated_emoji.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_animated_dialog/flutter_animated_dialog.dart';
 import 'package:watch_it/watch_it.dart';
 import 'package:yaru/yaru.dart';
 
@@ -110,8 +111,9 @@ class _LocalAudioPageState extends State<LocalAudioPage> {
                   ImportantButton(
                     child: Text(context.l10n.settings),
                     onPressed: () {
-                      showDialog(
+                      showAnimatedDialog(
                         context: context,
+                        animationType: DialogTransitionType.fade,
                         builder: (_) => const SettingsDialog(),
                       );
                     },

--- a/lib/patch_notes/patch_notes_dialog.dart
+++ b/lib/patch_notes/patch_notes_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:animated_emoji/animated_emoji.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_animated_dialog/flutter_animated_dialog.dart';
 import 'package:watch_it/watch_it.dart';
 
 import '../extensions/build_context_x.dart';
@@ -59,9 +60,9 @@ class PatchNotesDialog extends StatelessWidget {
 Future<void> showPatchNotes(BuildContext context) {
   final settingsModel = di<SettingsModel>();
   if (settingsModel.recentPatchNotesDisposed == true) return Future.value();
-  return showDialog(
-    barrierDismissible: false,
+  return showAnimatedDialog(
     context: context,
+    animationType: DialogTransitionType.fade,
     builder: (context) {
       return PatchNotesDialog(
         disposePatchNotes: settingsModel.disposePatchNotes,

--- a/lib/player/view/queue_button.dart
+++ b/lib/player/view/queue_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animated_dialog/flutter_animated_dialog.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:watch_it/watch_it.dart';
 
@@ -29,8 +30,9 @@ class QueueButton extends StatelessWidget {
         color: color ?? theme.colorScheme.onSurface,
       ),
       onPressed: () {
-        showDialog(
+        showAnimatedDialog(
           context: context,
+          animationType: DialogTransitionType.fade,
           builder: (context) {
             return QueueDialog(
               addPlaylist: libraryModel.addPlaylist,

--- a/lib/playlists/view/playlist_page.dart
+++ b/lib/playlists/view/playlist_page.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:audio_metadata_reader/audio_metadata_reader.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_animated_dialog/flutter_animated_dialog.dart';
 import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 import 'package:watch_it/watch_it.dart';
 import 'package:yaru/theme.dart';
@@ -243,8 +244,9 @@ class _PlaylistPageBody extends StatelessWidget with WatchItMixin {
         IconButton(
           tooltip: context.l10n.editPlaylist,
           icon: Icon(Iconz().pen),
-          onPressed: () => showDialog(
+          onPressed: () => showAnimatedDialog(
             context: context,
+            animationType: DialogTransitionType.fade,
             builder: (context) => AlertDialog(
               content: SizedBox(
                 height: 200,
@@ -269,8 +271,9 @@ class _PlaylistPageBody extends StatelessWidget with WatchItMixin {
         IconButton(
           tooltip: context.l10n.add,
           icon: Icon(Iconz().plus),
-          onPressed: () => showDialog(
+          onPressed: () => showAnimatedDialog(
             context: context,
+            animationType: DialogTransitionType.fade,
             builder: (context) => PlaylistAddAudiosDialog(playlistId: pageId),
           ),
         ),

--- a/lib/podcasts/view/podcast_audio_tile.dart
+++ b/lib/podcasts/view/podcast_audio_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animated_dialog/flutter_animated_dialog.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:yaru/yaru.dart';
@@ -220,8 +221,9 @@ class _Description extends StatelessWidget {
     return InkWell(
       borderRadius: BorderRadius.circular(8),
       onTap: () {
-        showDialog(
+        showAnimatedDialog(
           context: context,
+          animationType: DialogTransitionType.fade,
           builder: (c) {
             return SimpleDialog(
               titlePadding: yaruStyled

--- a/lib/radio/view/radio_history_tile.dart
+++ b/lib/radio/view/radio_history_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animated_dialog/flutter_animated_dialog.dart';
 import 'package:watch_it/watch_it.dart';
 import 'package:yaru/constants.dart';
 
@@ -42,8 +43,9 @@ class RadioHistoryTile extends StatelessWidget with PlayerMixin {
       ),
       trailing: IconButton(
         tooltip: context.l10n.metadata,
-        onPressed: () => showDialog(
+        onPressed: () => showAnimatedDialog(
           context: context,
+          animationType: DialogTransitionType.fade,
           builder: (context) {
             final image = UrlStore().get(entry.value.icyTitle);
             return MpvMetadataDialog(

--- a/lib/settings/view/settings_tile.dart
+++ b/lib/settings/view/settings_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animated_dialog/flutter_animated_dialog.dart';
 import 'package:path/path.dart' as p;
 import 'package:url_launcher/url_launcher.dart';
 import 'package:watch_it/watch_it.dart';
@@ -33,8 +34,9 @@ class SettingsTile extends StatelessWidget {
           YaruMasterTile(
             leading: Icon(Iconz().settings),
             title: Text(context.l10n.settings),
-            onTap: () => showDialog(
+            onTap: () => showAnimatedDialog(
               context: context,
+              animationType: DialogTransitionType.fade,
               builder: (_) => const SettingsDialog(),
             ),
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -495,6 +495,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_animated_dialog:
+    dependency: "direct main"
+    description:
+      name: flutter_animated_dialog
+      sha256: "16b88e56ea7014925a1ed4c3c3644f735edfe9194d5cc027a1a10a95d8f55fce"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   flutter_cache_manager:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   file_selector_linux: ^0.9.2+1
   flutter:
     sdk: flutter
+  flutter_animated_dialog: ^2.0.1
   flutter_cache_manager: ^3.3.1
   flutter_html: ^3.0.0-beta.2
   flutter_localizations:


### PR DESCRIPTION
Import `flutter_animated_dialog` and use the `showAnimatedDialog` method instead of `showDialog`.

Note that you should avoid setting `barrierDismissible` to `true` if possible. Multiple clicks on the button calling the showAnimatedDialog method can lead to the following exception:

`FlutterError: Duplicate GlobalKey detected in widget tree.`