### PR TITLE
chore: reactivate_snap_creation

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,13 +1,10 @@
 name: Create Snap Package
 
 on:
-#   push:
-#     branches:
-#       - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
-
-env:
-  FLUTTER_VERSION: '3.29.0'
 
 jobs:
   build_and_release_linux_snap_edge_amd64:
@@ -16,13 +13,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 5
-      - uses: subosito/flutter-action@v2
+      - uses: snapcore/action-build@v1
+        id: build
+      - uses: snapcore/action-publish@v1
+        if: steps.build.outcome == 'success'
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
-          channel: 'stable'
-          flutter-version: ${{env.FLUTTER_VERSION}}
-      - run: sudo apt update
-      - run: sudo apt install -y clang cmake curl libgtk-3-dev ninja-build pkg-config unzip libunwind-dev libmpv-dev
-      - run: flutter pub get
+          snap: ${{ steps.build.outputs.snap }}
+          release: edge
+
+  build_and_release_linux_snap_edge_arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 5
       - uses: snapcore/action-build@v1
         id: build
       - uses: snapcore/action-publish@v1


### PR DESCRIPTION
Reactivate the snap creation from github actions, because finally github supports linux arm runners, too. Thus snapcraft is no longer needed (hopefully), also because the auto snap creation trigger seems to be bugged on snapcraft.