### PR TITLE
fix: ambersand in podcast title shown as `&amp`

### DIFF
--- a/lib/extensions/string_x.dart
+++ b/lib/extensions/string_x.dart
@@ -1,3 +1,4 @@
+import 'package:html/parser.dart';
 import '../common/data/audio.dart';
 
 extension StringExtension on String {
@@ -64,4 +65,6 @@ extension NullableStringX on String? {
     micros = (double.parse(parts[parts.length - 1]) * 1000000).round();
     return Duration(hours: hours, minutes: minutes, microseconds: micros);
   }
+
+  String? get unEscapeHtml => HtmlParser(this).parseFragment().text ?? this;
 }

--- a/lib/player/player_service.dart
+++ b/lib/player/player_service.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 
 import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
-import 'package:html/parser.dart';
 import 'package:media_kit/media_kit.dart' hide PlayerState;
 import 'package:media_kit_video/media_kit_video.dart';
 import 'package:path/path.dart' as p;

--- a/lib/player/player_service.dart
+++ b/lib/player/player_service.dart
@@ -848,7 +848,7 @@ class PlayerService {
       return;
     }
     final newData = MpvMetaData.fromJson(data);
-    final parsedIcyTitle = HtmlParser(newData.icyTitle).parseFragment().text;
+    final parsedIcyTitle = newData.icyTitle.unEscapeHtml;
     if (parsedIcyTitle == null || parsedIcyTitle == _mpvMetaData?.icyTitle) {
       return;
     }

--- a/lib/player/view/player_title_and_artist.dart
+++ b/lib/player/view/player_title_and_artist.dart
@@ -9,6 +9,7 @@ import '../../common/data/audio_type.dart';
 import '../../common/view/copy_clipboard_content.dart';
 import '../../common/view/snackbars.dart';
 import '../../extensions/build_context_x.dart';
+import '../../extensions/string_x.dart';
 import '../../l10n/l10n.dart';
 import '../../local_audio/local_audio_model.dart';
 import '../../local_audio/view/album_page.dart';
@@ -186,7 +187,7 @@ class PlayerTitleAndArtist extends StatelessWidget with WatchItMixin {
       );
 
   String _subTitle(Audio? audio) => (switch (audio?.audioType) {
-            AudioType.podcast => audio?.album,
+            AudioType.podcast => audio?.album?.unEscapeHtml,
             AudioType.radio => audio?.title,
             _ => audio?.artist
           } ??

--- a/lib/podcasts/view/podcast_page_header.dart
+++ b/lib/podcasts/view/podcast_page_header.dart
@@ -1,6 +1,5 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:html/parser.dart';
 import 'package:watch_it/watch_it.dart';
 
 import '../../app/view/routing_manager.dart';
@@ -9,6 +8,7 @@ import '../../common/data/audio_type.dart';
 import '../../common/page_ids.dart';
 import '../../common/view/audio_page_header.dart';
 import '../../common/view/audio_page_header_html_description.dart';
+import '../../extensions/string_x.dart';
 import '../../l10n/l10n.dart';
 import '../../search/search_model.dart';
 import '../../settings/settings_model.dart';
@@ -41,7 +41,7 @@ class PodcastPageHeader extends StatelessWidget {
               description: episodes!.firstOrNull!.albumArtist!,
               title: title,
             ),
-      title: HtmlParser(title).parseFragment().text ?? title,
+      title: title.unEscapeHtml ?? title,
       onLabelTab: (text) => _onGenreTap(
         l10n: l10n,
         text: text,

--- a/lib/podcasts/view/podcast_page_title.dart
+++ b/lib/podcasts/view/podcast_page_title.dart
@@ -1,6 +1,5 @@
-import 'package:html/parser.dart';
-
 import '../../extensions/build_context_x.dart';
+import '../../extensions/string_x.dart';
 import '../../l10n/l10n.dart';
 import '../../library/library_model.dart';
 import 'package:flutter/material.dart';
@@ -41,7 +40,7 @@ class _PodcastPageTitleState extends State<PodcastPageTitle> {
       alignment: Alignment.centerRight,
       child: Padding(
         padding: EdgeInsets.only(right: visible ? 10 : 0),
-        child: Text(HtmlParser(title).parseFragment().text ?? title),
+        child: Text(title.unEscapeHtml ?? title),
       ),
     );
   }

--- a/lib/podcasts/view/podcasts_collection_body.dart
+++ b/lib/podcasts/view/podcasts_collection_body.dart
@@ -18,6 +18,7 @@ import '../../common/view/safe_network_image.dart';
 import '../../common/view/theme.dart';
 import '../../custom_content/custom_content_model.dart';
 import '../../extensions/build_context_x.dart';
+import '../../extensions/string_x.dart';
 import '../../l10n/l10n.dart';
 import '../../library/library_model.dart';
 import '../../player/player_model.dart';
@@ -172,7 +173,7 @@ class PodcastsCollectionBody extends StatelessWidget with WatchItMixin {
                                   )
                               : null,
                           text:
-                              first?.album ?? first?.title ?? first.toString(),
+                              first?.album?.unEscapeHtml ?? first?.title ?? first.toString(),
                         ),
                         onPlay: () => di<PlayerModel>()
                             .startPlaylist(

--- a/lib/podcasts/view/podcasts_collection_body.dart
+++ b/lib/podcasts/view/podcasts_collection_body.dart
@@ -172,8 +172,9 @@ class PodcastsCollectionBody extends StatelessWidget with WatchItMixin {
                                     fontWeight: FontWeight.bold,
                                   )
                               : null,
-                          text:
-                              first?.album?.unEscapeHtml ?? first?.title ?? first.toString(),
+                          text: first?.album?.unEscapeHtml ??
+                              first?.title ??
+                              first.toString(),
                         ),
                         onPlay: () => di<PlayerModel>()
                             .startPlaylist(


### PR DESCRIPTION
## Issue
Closes #1261 

## Context
This commit introduces a new extension getter `unEscapeHtml` to unescape html entities from strings using
`HtmlParser(...).parseFragment().text`. Replace all direct use of same with the new `unEscapeHtml` getter.

## Screenshots
<img width="1432" alt="Screenshot 2025-05-11 at 12 06 38 AM" src="https://github.com/user-attachments/assets/635cc2b8-19bf-42a3-9d66-e7f6d5f8557d" />
